### PR TITLE
Update DSN needed to create NullTransport

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -745,7 +745,7 @@ environment:
     # config/packages/dev/mailer.yaml
     framework:
         mailer:
-            dsn: 'null://null'
+            dsn: 'smtp://null'
 
 .. note::
 


### PR DESCRIPTION
\Symfony\Component\Mailer\Transport::createTransport() shows that "smtp://null" must be used instead of suggested "null://null"

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
